### PR TITLE
add usage error for invalid keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ class Swarm extends EventEmitter {
 
   join (key, opts) {
     if (!opts) opts = {}
+    checkKey(key)
 
     this._bind()
     this.leave(key)
@@ -47,6 +48,8 @@ class Swarm extends EventEmitter {
   }
 
   leave (key) {
+    checkKey(key)
+
     const hex = key.toString('hex')
     const prev = this._topics.get(hex)
     if (prev) prev.destroy()
@@ -129,6 +132,12 @@ class Swarm extends EventEmitter {
       self.emit('connection', socket, info)
       self._connectNext() // TODO: don't be this eager
     })
+  }
+}
+
+function checkKey (key) {
+  if (!Buffer.isBuffer(key) || key.byteLength !== 32) {
+    throw new Error('Wrong key supplied, key must a 32 bytes Buffer.')
   }
 }
 


### PR DESCRIPTION
 - keys must be a Buffer
 - keys must be 32 bytes

this makes it easier for people to see what is wrogn when they
receive

```
/Users/robert/bitfinex/network/node_modules/xor-distance/index.js:4
  if (a.length !== b.length) throw new Error('Inputs should have the same length')
                                   ^

Error: Inputs should have the same length
    at dist (/Users/robert/bitfinex/network/node_modules/xor-distance/index.js:4:36)
```

or:

```
/Users/robert/bitfinex/hcbench/node_modules/k-bucket/index.js:60
    throw new TypeError(name + ' is not a Uint8Array')
    ^

TypeError: id is not a Uint8Array
    at ensureInt8 (/Users/robert/bitfinex/hcbench/node_modules/k-bucket/index.js:60:11)
```

relaeted: #11