### PR TITLE
Add a destroy function

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,25 @@ class Swarm extends EventEmitter {
     if (prev) prev.destroy()
   }
 
+  // This function should close all open handles and requests
+  destroy (cb) {
+    this._topics.forEach(t => {
+      if (t) {
+        this.leave(t)
+      }
+    })
+
+    this.discovery.destroy()
+    this.discovery.dht.destroy()
+    this.discovery.on('close', () => {
+      this.server.close(() => {
+        this.socket.close(() => {
+          if (cb) cb()
+        })
+      })
+    })
+  }
+
   connect (peer, cb) {
     var utp = null
     var missing = 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperswarm/network",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The Hyperswarm network stack",
   "main": "index.js",
   "dependencies": {
@@ -9,10 +9,11 @@
   },
   "devDependencies": {
     "standard": "^12.0.1",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "why-is-node-running": "^2.0.3"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard && node tests"
   },
   "repository": {
     "type": "git",

--- a/tests/destroy.test.js
+++ b/tests/destroy.test.js
@@ -1,0 +1,48 @@
+const log = require('why-is-node-running')
+const test = require('tape')
+const network = require('../')
+const crypto = require('crypto')
+
+function createNetwork () {
+  const net = network({
+    ephemeral: true
+  })
+
+  net.discovery.holepunchable((err, yes) => {
+    console.log('network is hole punchable?', err, yes)
+    if (err) throw new Error('This test will not pass since the network is not HolePunchAble: ', err)
+  })
+  return net
+}
+
+function joinNetwork (net, topic) {
+  const k = crypto.createHash('sha256')
+    .update(topic)
+    .digest()
+  net.join(k, {
+    announce: false,
+    lookup: true
+  })
+}
+
+function destroy (t) {
+  let handles = process._getActiveHandles()
+  console.log('handles length = ', handles.length)
+  let requests = process._getActiveRequests()
+  console.log('requests length = ', requests.length)
+  log()
+  t.end()
+}
+// Unfortunately, this test will hang if it fails.
+test('Make sure we can destroy the network with a UTP socket in a second', t => {
+  t.pass('We can pass!')
+  let topics = ['topic1', 'topic2']
+  let net1 = createNetwork()
+  topics.forEach(topic => {
+    joinNetwork(net1, topic)
+  })
+  let timeToWait = 200 // We need an "onready" event so I don't have to do this.
+  setTimeout(() => {
+    net1.destroy(destroy(t))
+  }, timeToWait)
+})

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,1 @@
+require('./destroy.test.js')


### PR DESCRIPTION
- Currently there is no way to destroy the network directly, this merge request
  attempts to solve that issue.
- There are accompanying tests, but they have an issue where they don't exit
  if this test fails.
- It would be nice if there was a way to exit the test if the process handles
  are above a certain threshold, although preliminary tests show that there
  wasn't really a correlation between the number of handles and requests open
  and whether or not the test would exit.

Signed-off-by: Cody W. Eilar <Cody.Eilar@Gmail.com>