### PR TITLE
improve test leave/bind functionality, create correct keys in tests

### DIFF
--- a/swarm.js
+++ b/swarm.js
@@ -163,7 +163,11 @@ class Swarm extends EventEmitter {
     if (this.destroyed) return
 
     this.network.bind((err) => {
-      if (err) return // don't emit this, as we are leaving anyway
+      if (err) {
+        // swallow any errors but don't emit, as we are leaving anyway
+        // don't return early unless discovery is unavailable
+      }
+      if (!this.network.discovery) return
       this[kLeave](key)
       this.emit('leave', key)
     })


### PR DESCRIPTION
* tests the leave -> bind -> error path (gets 100% cov for swarm.js)
* alters error path to not return early unless network.discovery is not present (a bind error might not mean that topics can't be left)
* fixes keys in swarm.main.test.js to always be 32 bytes