### PR TITLE
queue: remove peers on ban, exhaust

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -72,7 +72,12 @@ class PeerQueue extends EventEmitter {
   requeue (info) {
     if (this.destroyed) return false
     const queue = info.requeue()
-    if (queue === -1) return false
+    if (queue === -1) {
+      // Either we exhausted reconnect attempts, the peer was banned or
+      // reconnect is disabled. In any case - we have to remove the peer.
+      this._remove[info.banned ? 1 : 0].push(info)
+      return false
+    }
     this._requeue[queue].push(info)
     return true
   }
@@ -89,7 +94,7 @@ class PeerQueue extends EventEmitter {
 
     // TODO: support a multiplex: true flag, that will make the info object emit a
     // 'topic' event instead of making dup connections, per topic
-    const id = toID(peer) + (peer.topic ? '@' + peer.topic.toString('hex') : '')
+    const id = toID(peer)
 
     let info = this._infos.get(id)
 
@@ -132,7 +137,8 @@ class PeerQueue extends EventEmitter {
 }
 
 function toID (peer) {
-  return peer.host + ':' + peer.port
+  return peer.host + ':' + peer.port +
+    (peer.topic ? '@' + peer.topic.toString('hex') : '')
 }
 
 module.exports.PeerQueue = PeerQueue


### PR DESCRIPTION
When peers are banned or their reconnect attempts were exhausted or were
disabled - they have to be queued for removal. Otherwise:

* Future re-discovery of peers will not result in reconnects
* Memory leak will happen

cc @mafintosh 