### PR TITLE
Stream multiplexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Options include:
       // how long to wait before fogetting that a peer 
       // has been banned
       banned: Infinity
-    }
+    },
+    // attempt to reuse existing connections between peers across multiple topics
+    multiplex: false
   }
 }
 ```
@@ -125,6 +127,7 @@ A new connection has been created. You should handle this event by using the soc
  - `details`. Object describing the connection.
    - `type`. String. Should be either `'tcp'` or `'utp'`.
    - `client`. Boolean. If true, the connection was initiated by this node.
+   - `topics`. Array. The list of topics associated with this connection (when `multiplex: true`)
    - `peer`. Object describing the peer. Will be null if `client === false`.
      - `port`. Number.
      - `host`. String. The IP address of the peer.
@@ -134,6 +137,8 @@ A new connection has been created. You should handle this event by using the soc
        - `host`. String. The IP address of the referrer.
        - `id`. Buffer.
      - `topic`. Buffer. The identifier which this peer was discovered under.
+     
+The `details` argument is a `PeerInfo` object, which will emit events of the form `details.on('topic', topic => ...)` when the `multiplex` flag is `true`.
 
 #### `swarm.on('disconnection', (socket, details) => {})`
 

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -1,4 +1,5 @@
 'use strict'
+const { EventEmitter } = require('events')
 
 module.exports = peer => new PeerInfo(peer)
 
@@ -12,14 +13,16 @@ const FIREWALLED = 0b100000
 const BANNED_OR_ACTIVE = BANNED | ACTIVE
 const ACTIVE_OR_TRIED = ACTIVE | TRIED
 
-class PeerInfo {
+class PeerInfo extends EventEmitter {
   constructor (peer = null) {
+    super()
     this.priority = (peer && peer.local) ? 3 : 2
     this.status = RECONNECT | FIREWALLED
     this.retries = 0
     this.peer = peer
     this.client = peer !== null
     this.stream = null
+    this.topics = []
     this._index = 0
   }
 
@@ -72,6 +75,14 @@ class PeerInfo {
 
   disconnected () {
     this.stream = null
+    // The info object is reused after disconnection, so we need to clear registered listeners/topics.
+    this.topics = []
+    this.removeAllListeners('topic')
+  }
+
+  topic (topic) {
+    this.topics.push(topic)
+    this.emit('topic', topic)
   }
 
   update () {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -40,6 +40,7 @@ class PeerQueue extends EventEmitter {
     this.destroyed = false
     this._infos = new Map()
     this._queue = spq()
+    this._multiplex = !!opts.multiplex
 
     const push = this._push.bind(this)
     const release = this._release.bind(this)
@@ -94,14 +95,17 @@ class PeerQueue extends EventEmitter {
 
     // TODO: support a multiplex: true flag, that will make the info object emit a
     // 'topic' event instead of making dup connections, per topic
-    const id = toID(peer)
+    const id = toID(peer, this._multiplex)
 
     let info = this._infos.get(id)
+    const existing = !!info
 
     if (!info) {
       info = peerInfo(peer)
       this._infos.set(id, info)
     }
+    info.topic(peer.topic)
+    if (this._multiplex && existing) return
 
     if (this._queue.has(info)) return
     if (!info.update()) return
@@ -136,9 +140,10 @@ class PeerQueue extends EventEmitter {
   }
 }
 
-function toID (peer) {
-  return peer.host + ':' + peer.port +
-    (peer.topic ? '@' + peer.topic.toString('hex') : '')
+function toID (peer, multiplex) {
+  const baseID = peer.host + ':' + peer.port
+  if (multiplex) return baseID
+  return baseID + (peer.topic ? '@' + peer.topic.toString('hex') : '')
 }
 
 module.exports.PeerQueue = PeerQueue

--- a/test/swarm.main.test.js
+++ b/test/swarm.main.test.js
@@ -2,7 +2,7 @@
 const { EventEmitter } = require('events')
 const { randomBytes } = require('crypto')
 const { NetworkResource } = require('@hyperswarm/network')
-const { test, skip } = require('tap')
+const { test, skip, only } = require('tap')
 const { once, done, promisifyMethod, whenifyMethod } = require('nonsynchronous')
 const { dhtBootstrap, validSocket } = require('./util')
 const hyperswarm = require('../swarm')
@@ -547,54 +547,75 @@ test('connections tracks active connections count correctly', async ({ is }) => 
   closeDht()
 })
 
-skip('can connect to 20 peers for different topics', async ({ ok }) => {
+only('can multiplex 100 topics over the same connection', async ({ same }) => {
   const { bootstrap, closeDht } = await dhtBootstrap()
-  const swarm1 = hyperswarm({ bootstrap })
-  const swarm2 = hyperswarm({ bootstrap })
+  const swarm1 = hyperswarm({ bootstrap, maxPeers: 20, queue: { multiplex: true } })
+  const swarm2 = hyperswarm({ bootstrap, maxPeers: 20, queue: { multiplex: true } })
 
-  const numTopics = 25
-  const keys = []
+  const numTopics = 100
+  var topics = []
 
+  // Announce all topics.
   for (let i = 0; i < numTopics; i++) {
-    const key = randomBytes(32)
-    keys.push(key)
-    swarm1.join(key, {
+    const topic = randomBytes(32)
+    topics.push(topic)
+    swarm1.join(topic, {
       announce: true,
       lookup: false
     })
-    swarm2.join(key, {
+  }
+
+  // Start listening for new connections, and briefly wait to flush the DHT.
+  const emittedTopicsPromise = listenForConnections(swarm2)
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Join all topics on the receiving end.
+  for (let i = 0; i < numTopics; i++) {
+    swarm2.join(topics[i], {
       announce: false,
       lookup: true
     })
   }
 
-  const keySet = new Set(keys.map(k => k.toString('hex')))
+  const topicSet = new Set(topics.map(t => t.toString('hex')))
   const failTimer = setTimeout(() => {
     throw new Error('Did not establish connections in time.')
   }, 5000)
+  const emittedTopics = await emittedTopicsPromise
 
-  const infos = await new Promise((resolve) => {
-    const infos = []
-    swarm2.on('connection', (socket, info) => {
-      infos.push(info)
-      if (infos.length === numTopics) {
-        clearTimeout(failTimer)
-        return resolve(infos)
-      }
-    })
-  })
-
-  for (const { peer } of infos) {
-    const keyString = peer.topic.toString('hex')
-    ok(keySet.has(keyString))
-    keySet.delete(keyString)
+  for (const topic of topics) {
+    const topicString = topic.toString('hex')
+    if (topicSet.has(topicString)) topicSet.delete(topicString)
   }
+  same(topicSet.size, 0)
 
-  for (const key of keys) {
-    swarm1.leave(key)
-    swarm2.leave(key)
+  for (const topic of topics) {
+    swarm1.leave(topic)
+    swarm2.leave(topic)
   }
   swarm1.destroy()
   swarm2.destroy()
   closeDht()
+
+  function listenForConnections (swarm) {
+    const emittedTopics = []
+    return new Promise(resolve => {
+      swarm.on('connection', (socket, info) => {
+        for (let topic of info.topics) {
+          pushTopic(topic)
+        }
+        info.on('topic', topic => {
+          pushTopic(topic)
+        })
+        function pushTopic (topic) {
+          emittedTopics.push(topic)
+          if (topics.length === numTopics) {
+            clearTimeout(failTimer)
+            info.removeAllListeners('topic')
+            return resolve(emittedTopics)
+          }
+        }
+      })
+    })
+  }
 })

--- a/test/swarm.main.test.js
+++ b/test/swarm.main.test.js
@@ -2,7 +2,7 @@
 const { EventEmitter } = require('events')
 const { randomBytes } = require('crypto')
 const { NetworkResource } = require('@hyperswarm/network')
-const { test, only } = require('tap')
+const { test, skip } = require('tap')
 const { once, done, promisifyMethod, whenifyMethod } = require('nonsynchronous')
 const { dhtBootstrap, validSocket } = require('./util')
 const hyperswarm = require('../swarm')
@@ -547,7 +547,7 @@ test('connections tracks active connections count correctly', async ({ is }) => 
   closeDht()
 })
 
-only('can connect to 20 peers for different topics', async ({ ok }) => {
+skip('can connect to 20 peers for different topics', async ({ ok }) => {
   const { bootstrap, closeDht } = await dhtBootstrap()
   const swarm1 = hyperswarm({ bootstrap })
   const swarm2 = hyperswarm({ bootstrap })


### PR DESCRIPTION
This PR adds a `multiplex` flag that, when enabled, will reuse existing connections across multiple topics. In order to support this, the `PeerInfo` class has been changed to an EventEmitter, which will emit `topic` events whenever a new topic has been added to the connection.

`PeerInfo` objects also have an added `topics` field, which is an Array of the current topics associated with the connection.

