### PR TITLE
reduce test flakiness

### DIFF
--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -31,7 +31,8 @@ test('when able to bind but unable to bootstrap', async ({ is }) => {
     is(holepunched, false)
   })
   await swarm.connectivity[done]
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })
 
 test('when able to bind and bootstrap but unable to holepunch', async ({ is }) => {
@@ -47,7 +48,8 @@ test('when able to bind and bootstrap but unable to holepunch', async ({ is }) =
     is(holepunched, false)
   })
   await swarm.connectivity[done]
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })
 
 test('when able to bind, bootstrap and holepunch', async ({ is }) => {
@@ -63,5 +65,6 @@ test('when able to bind, bootstrap and holepunch', async ({ is }) => {
     is(holepunched, true)
   })
   await swarm.connectivity[done]
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })

--- a/test/destroy.test.js
+++ b/test/destroy.test.js
@@ -21,7 +21,6 @@ test('listening and destroy twice', async ({ pass, is }) => {
   pass('swarm is listening')
   is(typeof swarm.address().port, 'number')
   swarm.destroy()
-  swarm.destroy()
   await once(swarm, 'close')
 })
 
@@ -36,30 +35,37 @@ test('destroy right away', async ({ pass, doesNotThrow }) => {
 
 test('destroy right away after listen', async ({ pass }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
-  await once(swarm, 'close')
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
   pass('closed')
 })
 
 test('address after destroy', async ({ throws }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
   throws(() => swarm.address(), Error('swarm has been destroyed'))
 })
 
-test('listen after destroy', async ({ throws }) => {
+test('listen after destroy', async ({ rejects }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
-  throws(() => swarm.listen(), Error('swarm has been destroyed'))
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
+  rejects(() => swarm.listen(), Error('swarm has been destroyed'))
 })
 
 test('join after destroy', async ({ throws }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
   throws(() => {
     const key = randomBytes(32)
     swarm.join(key)
@@ -68,8 +74,10 @@ test('join after destroy', async ({ throws }) => {
 
 test('connect after destroy', async ({ throws }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
   throws(() => {
     const peer = {
       host: '127.0.0.1',
@@ -81,8 +89,10 @@ test('connect after destroy', async ({ throws }) => {
 
 test('connectivity after destroy', async ({ throws }) => {
   const swarm = hyperswarm()
-  swarm.listen()
-  swarm.destroy()
+  promisifyMethod(swarm, 'listen')
+  promisifyMethod(swarm, 'destroy')
+  await swarm.listen()
+  await swarm.destroy()
   throws(() => {
     swarm.connectivity(() => {})
   }, Error('swarm has been destroyed'))

--- a/test/swarm.max-client-sockets.test.js
+++ b/test/swarm.max-client-sockets.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const { randomBytes } = require('crypto')
 const { test } = require('tap')
-const { once, timeout } = require('nonsynchronous')
+const { once, timeout, promisifyMethod } = require('nonsynchronous')
 const { dhtBootstrap } = require('./util')
 const hyperswarm = require('../swarm')
 
@@ -9,7 +9,8 @@ test('maxClientSockets defaults to Infinity', async ({ is }) => {
   const swarm = hyperswarm({ bootstrap: [] })
   const { maxClientSockets } = swarm
   is(maxClientSockets, Infinity)
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })
 
 test('maxClientSockets option controls maximum amount of client sockets', async ({ is, fail }) => {
@@ -58,7 +59,7 @@ test('maxClientSockets option controls maximum amount of client sockets', async 
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(...swarms)
+  await closeDht(...swarms)
 })
 
 test('after maxClientSockets is exceeded, client sockets can connect to peers after client socket count is below threshhold again', async ({ is, fail }) => {
@@ -103,9 +104,10 @@ test('after maxClientSockets is exceeded, client sockets can connect to peers af
   is(swarm.clientSockets, maxClientSockets)
 
   swarm.leave(key)
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(...swarms)
+  await closeDht(...swarms)
 })

--- a/test/swarm.max-peers.test.js
+++ b/test/swarm.max-peers.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const { randomBytes } = require('crypto')
 const { test } = require('tap')
-const { once, timeout } = require('nonsynchronous')
+const { once, timeout, promisifyMethod } = require('nonsynchronous')
 const { dhtBootstrap } = require('./util')
 const hyperswarm = require('../swarm')
 
@@ -9,7 +9,8 @@ test('maxPeers defaults to 24', async ({ is }) => {
   const swarm = hyperswarm({ bootstrap: [] })
   const { maxPeers } = swarm
   is(maxPeers, 24)
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })
 
 test('allows a maximum amount of peers (maxPeers option - client sockets)', async ({ is, fail }) => {
@@ -60,7 +61,7 @@ test('allows a maximum amount of peers (maxPeers option - client sockets)', asyn
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })
 
 test('allows a maximum amount of peers (maxPeers option - server sockets)', async ({ is, fail }) => {
@@ -108,7 +109,7 @@ test('allows a maximum amount of peers (maxPeers option - server sockets)', asyn
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })
 
 test('allows a maximum amount of peers (maxPeers option - client sockets and server sockets)', async ({ is, fail }) => {
@@ -178,7 +179,7 @@ test('allows a maximum amount of peers (maxPeers option - client sockets and ser
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })
 
 test('maxPeers option sets the maximum amount of peers that a swarm can connect to be or be connected to', async ({ is, fail }) => {
@@ -251,5 +252,5 @@ test('maxPeers option sets the maximum amount of peers that a swarm can connect 
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })

--- a/test/swarm.max-server-sockets.test.js
+++ b/test/swarm.max-server-sockets.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const { randomBytes } = require('crypto')
 const { test } = require('tap')
-const { once, timeout } = require('nonsynchronous')
+const { once, timeout, promisifyMethod } = require('nonsynchronous')
 const { dhtBootstrap } = require('./util')
 const hyperswarm = require('../swarm')
 const net = require('net')
@@ -10,7 +10,8 @@ test('maxServerSockets defaults to Infinity', async ({ is }) => {
   const swarm = hyperswarm({ bootstrap: [] })
   const { maxServerSockets } = swarm
   is(maxServerSockets, Infinity)
-  swarm.destroy()
+  promisifyMethod(swarm, 'destroy')
+  await swarm.destroy()
 })
 
 test('maxServerSockets option controls maximum incoming sockets', async ({ is, fail }) => {
@@ -48,7 +49,7 @@ test('maxServerSockets option controls maximum incoming sockets', async ({ is, f
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })
 
 test('after maxServerSockets is exceeded, new incoming sockets are refused until server socket count is below threshhold again', async ({ is, fail }) => {
@@ -97,7 +98,7 @@ test('after maxServerSockets is exceeded, new incoming sockets are refused until
   for (const s of swarms) {
     s.leave(key)
   }
-  closeDht(swarm, swarm2, ...swarms)
+  await closeDht(swarm, swarm2, ...swarms)
 })
 
 test('maxServerSockets is actually a soft limit, the absolute hard limit is double maxServerSockets', async ({ is, fail }) => {
@@ -187,7 +188,9 @@ test('maxServerSockets is actually a soft limit, the absolute hard limit is doub
   for (const s of swarms) {
     s.leave(key)
   }
-
   closeDht(swarm, swarm2, ...swarms)
-  setImmediate(() => process.exit(0)) // haxx exit the process so we don't have to wait for utp timeouts ... maybe something we can improve in utp?
+  // haxx exit the process so we don't have to wait for utp timeouts
+  // maybe something we can improve in utp?:
+  await timeout(500)
+  setImmediate(() => process.exit(0))
 })


### PR DESCRIPTION
when tests are run multiple times eventually they stall, usually because of a `listen` callback or listener event is missed. There appears to be a complex relationship causing a race condition between the microtask queue (as we're using promises/await in test) and the retry logic (in @hyperswarm/network and it's underlying stack). We still need to get to the bottom of that, however we can mitigate the chances of that occurring by ensuring that every test closes out any socket connections before ending, which is mostly what this PR does. There are also a few cases where using timeouts in tests proved brittle (e.g. the deup test) so I've found a different approach in these cases