### PR TITLE
Enforce 32-byte length on keys

### DIFF
--- a/swarm.js
+++ b/swarm.js
@@ -9,7 +9,7 @@ const MAX_CLIENT_SOCKETS = Infinity
 const MAX_PEERS = 24
 
 const ERR_DESTROYED = 'swarm has been destroyed'
-const ERR_MISSING_KEY = 'key is required and must be a buffer'
+const ERR_MISSING_KEY = 'key is required and must be a 32-byte buffer'
 const ERR_JOIN_OPTS = 'join options must enable lookup, announce or both, but not neither'
 
 const kDrain = Symbol('hyperswarm.drain')
@@ -184,7 +184,7 @@ class Swarm extends EventEmitter {
 
     const { network } = this
 
-    if (Buffer.isBuffer(key) === false) throw Error(ERR_MISSING_KEY)
+    if (Buffer.isBuffer(key) === false || key.length !== 32) throw Error(ERR_MISSING_KEY)
 
     const { announce = false, lookup = true } = opts
 
@@ -219,7 +219,7 @@ class Swarm extends EventEmitter {
     })
   }
   leave (key, onleave) {
-    if (Buffer.isBuffer(key) === false) throw Error(ERR_MISSING_KEY)
+    if (Buffer.isBuffer(key) === false || key.length !== 32) throw Error(ERR_MISSING_KEY)
     if (this.destroyed) return
 
     this[kStatus].delete(key.toString('hex'))


### PR DESCRIPTION
The docs say that both join() and leave() require keys to be 32 bytes, but it's buried in the docs and neither one complains if you give them a Buffer with a different length.  They just aren't reliable.  This enforces that 32 byte length, adds tests to make sure it's enforcing it, and gives a more helpful error message if you don't abide by that restriction.

I ran into a whole bunch of weird issues when trying to port multiserver-dht from discovery-swarm to Hyperswarm.  Turns out a lot of the problems I was running into were due to Hyperswarm expecting a 32 byte key but not complaining if a shorter one was passed to it, which was quite unlike how discovery-swarm worked.  Basically independently discovered and encountered the problem in #11.