### PR TITLE
Add joinPeer/leavePeer methods to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ If a topic was previously joined in server mode, `leave` will stop announcing th
 
 `leave` will __not__ close any existing connections.
 
+#### `swarm.joinPeer(noisePublicKey)`
+Establish a direct connection to a known peer.
+
+`noisePublicKey` must be a 32-byte Buffer
+
+As with the standard `join` method, `joinPeer` will ensure that peer connections are reestablished in the event of failures.
+
+#### `swarm.leavePeer(noisePublicKey)`
+Stop attempting direct connections to a known peer.
+
+`noisePublicKey` must be a 32-byte Buffer
+
+If a direct connection is already established, that connection will __not__ be destroyed by `leavePeer`.
+
 #### `const discovery = swarm.status(topic)`
 Get the [`PeerDiscovery`](https://github.com/hyperswarm/hyperswarm/blob/v3/README.md#peerdiscovery-api) object associated with the topic, if it exists.
 

--- a/test/peer-join.js
+++ b/test/peer-join.js
@@ -1,0 +1,90 @@
+const Hyperswarm = require('..')
+const { test, destroyAll, planPromise } = require('./helpers')
+
+test('join peer - can establish direct connections to public keys', async (bootstrap, t) => {
+  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm2 = new Hyperswarm({ bootstrap })
+
+  await swarm2.listen() // Ensure that swarm2's public key is being announced
+
+  const plan = planPromise(t, 4)
+  const firstConnection = planPromise(t, 1)
+  let s2Connected = false
+
+  swarm2.on('connection', conn => {
+    if (!s2Connected) {
+      firstConnection.pass('swarm2 got its first connection')
+      s2Connected = true
+    }
+    plan.pass('swarm2 got a connection')
+  })
+  swarm1.on('connection', conn => {
+    plan.pass('swarm1 got a connection')
+  })
+
+  swarm1.joinPeer(swarm2.keyPair.publicKey)
+  await firstConnection
+
+  for (const conn of swarm1.connections) {
+    conn.end()
+  }
+  for (const conn of swarm2.connections) {
+    conn.end()
+  }
+  await swarm1.flush() // Should reconnect
+
+  await plan
+
+  await destroyAll(swarm1, swarm2)
+})
+
+test('leave peer - will stop reconnecting to previously joined peers', async (bootstrap, t) => {
+  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm2 = new Hyperswarm({ bootstrap })
+
+  await swarm2.listen() // Ensure that swarm2's public key is being announced
+
+  const openPlan = planPromise(t, 2)
+  const closePlan = planPromise(t, 2)
+
+  swarm2.on('connection', conn => {
+    conn.once('close', () => closePlan.pass('swarm2 connection closed'))
+    openPlan.pass('swarm2 got a connection')
+  })
+  swarm1.on('connection', conn => {
+    conn.once('close', conn => closePlan.pass('swarm1 connection closed'))
+    openPlan.pass('swarm1 got a connection')
+  })
+
+  swarm1.joinPeer(swarm2.keyPair.publicKey)
+
+  await openPlan
+
+  swarm1.removeAllListeners('connection')
+  swarm2.removeAllListeners('connection')
+
+  swarm1.leavePeer(swarm2.keyPair.publicKey)
+  t.same(swarm1.explicitPeers.size, 0)
+  t.same(swarm1.connections.size, 1)
+  t.same(swarm2.connections.size, 1)
+
+  swarm2.on('connection', conn => {
+    t.fail('swarm2 got a connection after leave')
+  })
+  swarm1.on('connection', conn => {
+    t.fail('swarm1 got a connection after leave')
+  })
+
+  for (const conn of swarm1.connections) {
+    conn.end()
+  }
+  for (const conn of swarm2.connections) {
+    conn.end()
+  }
+  await closePlan
+
+  t.same(swarm1.connections.size, 0)
+  t.same(swarm2.connections.size, 0)
+
+  await destroyAll(swarm1, swarm2)
+})


### PR DESCRIPTION
With `join` and `leave`, you can connect to groups of peers swarming around a common topic. Hyperswarm ensures that these peers connections are retried after failures. These methods don't let you specify which peers to connect to.

WIth these new `joinPeer` and `leavePeer` methods, you can directly connect to a known peer with a given Noise public key, and Hyperswarm will use the same reconnect logic on the resulting connections. 

__This PR depends on https://github.com/hyperswarm/hyperswarm/pull/83, so review that first__