### PR TITLE
Add `dht` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 sandbox.js
 sandbox
 .nyc_output

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Construct a new Hyperswarm instance.
 `opts` can include:
 * `keyPair`: A Noise keypair that will be used to listen/connect on the DHT. Defaults to a new key pair.
 * `seed`: A unique, 32-byte, random seed that can be used to deterministically generate the key pair.
-* `maxPeers`: The maximum number of peer connections to allow
+* `maxPeers`: The maximum number of peer connections to allow.
 * `firewall`: A sync function of the form `remotePublicKey => (true|false)`. If true, the connection will be rejected. Defaults to allowing all connections.
+* `dht`: A DHT instance. Defaults to a new instance.
 
 #### `swarm.connections`
 A set of all active client/server connections.

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     const networkOpts = {}
     if (opts.bootstrap) networkOpts.bootstrap = opts.bootstrap
-    this.dht = new DHT(networkOpts)
+    this.dht = opts.dht || new DHT(networkOpts)
 
     this.server = this.dht.createServer({
       firewall: this._handleFirewall.bind(this),

--- a/index.js
+++ b/index.js
@@ -33,12 +33,9 @@ module.exports = class Hyperswarm extends EventEmitter {
     if (opts.bootstrap) networkOpts.bootstrap = opts.bootstrap
     this.dht = opts.dht || new DHT(networkOpts)
 
-    this.server = this.dht.createServer(
-      {
-        firewall: this._handleFirewall.bind(this)
-      },
-      this._handleServerConnection.bind(this)
-    )
+    this.server = this.dht.createServer({
+      firewall: this._handleFirewall.bind(this)
+    }, this._handleServerConnection.bind(this))
 
     this.destroyed = false
     this.maxPeers = maxPeers

--- a/index.js
+++ b/index.js
@@ -33,9 +33,8 @@ module.exports = class Hyperswarm extends EventEmitter {
     if (opts.bootstrap) networkOpts.bootstrap = opts.bootstrap
     this.dht = opts.dht || new DHT(networkOpts)
 
-    this.server = this.dht.createServer({
-      firewall: this._handleFirewall.bind(this),
-      onconnection: this._handleServerConnection.bind(this)
+    this.server = this.dht.createServer(this._handleServerConnection.bind(this), {
+      firewall: this._handleFirewall.bind(this)
     })
 
     this.destroyed = false

--- a/index.js
+++ b/index.js
@@ -33,9 +33,12 @@ module.exports = class Hyperswarm extends EventEmitter {
     if (opts.bootstrap) networkOpts.bootstrap = opts.bootstrap
     this.dht = opts.dht || new DHT(networkOpts)
 
-    this.server = this.dht.createServer(this._handleServerConnection.bind(this), {
-      firewall: this._handleFirewall.bind(this)
-    })
+    this.server = this.dht.createServer(
+      {
+        firewall: this._handleFirewall.bind(this)
+      },
+      this._handleServerConnection.bind(this)
+    )
 
     this.destroyed = false
     this.maxPeers = maxPeers

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A distributed networking stack for connecting peers",
   "dependencies": {
     "@hyperswarm/dht": "next",
+    "events": "^3.3.0",
     "shuffled-priority-queue": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows using a relay node (https://github.com/hyperswarm/dht-relay) as a drop-in for the normal DHT.