### PR TITLE
fix: don't require hyperswarm/dht in browser

### DIFF
--- a/dht.browser.js
+++ b/dht.browser.js
@@ -1,0 +1,7 @@
+module.exports = class DHT {
+  constructor () {
+    throw new Error(
+      'Hyperswarm/DHT is not supported in browsers, please pass a dht-relay instance to Hyperswarm constructor'
+    )
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { EventEmitter } = require('events')
 const DHT = require('@hyperswarm/dht')
 const spq = require('shuffled-priority-queue')
+const crypto = require('hypercore-crypto')
 
 const PeerInfo = require('./lib/peer-info')
 const RetryTimer = require('./lib/retry-timer')
@@ -20,7 +21,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     super()
     const {
       seed,
-      keyPair = DHT.keyPair(seed),
+      keyPair = crypto.keyPair(seed),
       maxPeers = MAX_PEERS,
       maxClientConnections = MAX_CLIENT_CONNECTIONS,
       maxServerConnections = MAX_SERVER_CONNECTIONS,

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "hyperswarm",
   "version": "3.0.1",
   "description": "A distributed networking stack for connecting peers",
+  "browser": {
+    "@hyperswarm/dht": "./dht.browser.js"
+  },
   "dependencies": {
     "@hyperswarm/dht": "next",
     "events": "^3.3.0",
-    "shuffled-priority-queue": "^2.1.0"
+    "shuffled-priority-queue": "^2.1.0",
+    "hypercore-crypto": "^3.1.1"
   },
   "devDependencies": {
-    "hypercore-crypto": "^2.3.0",
     "math-random-seed": "^2.0.0",
     "nonsynchronous": "^1.2.0",
     "standard": "^12.0.1",


### PR DESCRIPTION
- Use keyPair from browser compatible hypercore-crypto instead
- Use dht.browser.js to throw an error in browser