### PR TITLE
docs: update note about v2 vs v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A high-level API for finding and connecting to peers who are interested in a "to
 
 ## NOTE: v3
 
-Note that this is the README for v3 which is tagged under next. To see the v2 documentation/code go to https://github.com/hyperswarm/hyperswarm/tree/v2
-
-As v3 fully matures over the next month it will be shifted to npm latest.
+Note that this is the README for v3. To see the v2 documentation/code go to https://github.com/hyperswarm/hyperswarm/tree/v2.
 
 ## Installation
 ```


### PR DESCRIPTION
Hey hyperfriends!

Taking a stroll through the swarm and I noticed your readme mentions v3 being tagged under `next`. However it looks like `3.0.2` is tagged `latest` now.

```
dist-tags:
latest: 3.0.2  next: 3.0.1
```
(via `npm info`)

So I thought I'd help future visitors by updating the readme to remove the mention of `next` tag for v3, while still distinguishing between v2 and v3 docs.