### PR TITLE
Add ignoreLimits option to joinPeer

### DIFF
--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -6,6 +6,7 @@ const LOW_PRIORITY = 1
 const NORMAL_PRIORITY = 2
 const HIGH_PRIORITY = 3
 const VERY_HIGH_PRIORITY = 4
+const TOP_PRIORITY = 5
 
 module.exports = class PeerInfo extends EventEmitter {
   constructor ({ publicKey, relayAddresses }) {
@@ -18,6 +19,7 @@ module.exports = class PeerInfo extends EventEmitter {
     this.proven = false
     this.banned = false
     this.tried = false
+    this.ignoreLimits = false
 
     // Set by the Swarm
     this.queued = false
@@ -46,6 +48,7 @@ module.exports = class PeerInfo extends EventEmitter {
   }
 
   _getPriority () {
+    if (this.ignoreLimits) return TOP_PRIORITY
     const peerIsStale = this.tried && !this.proven
     if (peerIsStale || this.attempts > 3) return VERY_LOW_PRIORITY
     if (this.attempts === 3) return LOW_PRIORITY


### PR DESCRIPTION
With `ignoreLimits`, the peer will be continuously retried regardless of if the swarm has reached its connection limit.

Use with care.