### PR TITLE
Joining the same topic repeatedly will refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hyperswarm/dht": "^6.0.1",
     "b4a": "^1.3.1",
     "events": "^3.3.0",
+    "safety-catch": "^1.0.2",
     "shuffled-priority-queue": "^2.1.0"
   },
   "devDependencies": {

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -475,4 +475,28 @@ test('flush when max connections reached', async (t) => {
   await swarm3.destroy()
 })
 
+test('rejoining with different client/server opts refreshes', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm2 = new Hyperswarm({ bootstrap })
+
+  const topic = Buffer.alloc(32).fill('hello world')
+
+  swarm1.join(topic, { client: true, server: false })
+  await swarm1.join(topic, { client: true, server: true }).flushed()
+
+  await swarm2
+    .on('connection', (conn) => conn.on('error', noop))
+    .join(topic, { client: true })
+    .flushed()
+
+  await swarm2.flush()
+
+  t.is(swarm2.connections.size, 1)
+
+  await swarm1.destroy()
+  await swarm2.destroy()
+})
+
 function noop () {}


### PR DESCRIPTION
Right now if you `swarm.join(topic)` multiple times with different `client`/`server` options, the swarm will only respect the first join's options. With this fix, the discovery will be refreshed with the latest options.