### PR TITLE
Support independent discovery sessions

### DIFF
--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -1,14 +1,20 @@
+const safetyCatch = require('safety-catch')
+
 const REFRESH_INTERVAL = 1000 * 60 * 10 // 10 min
 const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
 const DELAY_GRACE_PERIOD = 1000 * 30 // 30s
 
 module.exports = class PeerDiscovery {
-  constructor (swarm, topic, { server = true, client = true, onpeer = noop, onerror = noop }) {
+  constructor (swarm, topic, { onpeer = noop, onerror = noop }) {
     this.swarm = swarm
     this.topic = topic
-    this.isClient = client
-    this.isServer = server
+    this.isClient = false
+    this.isServer = false
     this.destroyed = false
+
+    this._sessions = []
+    this._clientSessions = 0
+    this._serverSessions = 0
 
     this._onpeer = onpeer
     this._onerror = onerror
@@ -20,6 +26,20 @@ module.exports = class PeerDiscovery {
     this._firstAnnounce = true
 
     this.refresh().catch(this._onerror)
+  }
+
+  session ({ server = true, client = true }) {
+    if (this.destroyed) throw new Error('PeerDiscovery is destroyed')
+
+    if (client) this._clientSessions++
+    if (server) this._serverSessions++
+
+    const session = new PeerDiscoverySession(this, { server, client })
+    this._sessions.push(session)
+
+    this.refresh().catch(safetyCatch)
+
+    return session
   }
 
   _refreshLater (eager) {
@@ -72,9 +92,11 @@ module.exports = class PeerDiscovery {
     this._closestNodes = query.closestNodes
   }
 
-  async refresh ({ client = this.isClient, server = this.isServer } = {}) {
+  async refresh () {
     if (this.destroyed) throw new Error('PeerDiscovery is destroyed')
-    if (!client && !server) throw new Error('Cannot refresh with neither client nor server option')
+
+    const server = this._serverSessions > 0
+    const client = this._clientSessions > 0
 
     if (server) await this.swarm.listen()
     if (this.destroyed) return
@@ -112,6 +134,10 @@ module.exports = class PeerDiscovery {
     }
   }
 
+  async _destroyMaybe () {
+    if (this._sessions.length === 0) await this.destroy()
+  }
+
   async destroy () {
     if (this.destroyed) return
     this.destroyed = true
@@ -135,6 +161,54 @@ module.exports = class PeerDiscovery {
 
     if (!this.isServer) return
     return this.swarm.dht.unannounce(this.topic, this.swarm.keyPair)
+  }
+}
+
+class PeerDiscoverySession {
+  constructor (discovery, { server = true, client = true }) {
+    this.discovery = discovery
+    this.isClient = client
+    this.isServer = server
+    this.destroyed = false
+  }
+
+  get swarm () {
+    return this.discovery.swarm
+  }
+
+  get topic () {
+    return this.discovery.topic
+  }
+
+  async refresh ({ client = this.isClient, server = this.isServer } = {}) {
+    if (this.destroyed) throw new Error('PeerDiscovery is destroyed')
+    if (!client && !server) throw new Error('Cannot refresh with neither client nor server option')
+
+    if (client !== this.isClient) {
+      this.discovery._clientSessions += client ? 1 : -1
+    }
+
+    if (server !== this.isServer) {
+      this.discovery._serverSessions += server ? 1 : -1
+    }
+
+    return this.discovery.refresh()
+  }
+
+  async flushed () {
+    return this.discovery.flushed()
+  }
+
+  async destroy () {
+    if (this.isClient) this.discovery._clientSessions--
+    if (this.isServer) this.discovery._serverSessions--
+
+    const index = this.discovery._sessions.indexOf(this)
+    const head = this.discovery._sessions.pop()
+
+    if (head !== this) this.discovery._sessions[index] = head
+
+    return this.discovery._destroyMaybe()
   }
 }
 

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -185,10 +185,12 @@ class PeerDiscoverySession {
     if (!client && !server) throw new Error('Cannot refresh with neither client nor server option')
 
     if (client !== this.isClient) {
+      this.isClient = client
       this.discovery._clientSessions += client ? 1 : -1
     }
 
     if (server !== this.isServer) {
+      this.isServer = server
       this.discovery._serverSessions += server ? 1 : -1
     }
 

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -202,6 +202,9 @@ class PeerDiscoverySession {
   }
 
   async destroy () {
+    if (this.destroyed) return
+    this.destroyed = true
+
     if (this.isClient) this.discovery._clientSessions--
     if (this.isServer) this.discovery._serverSessions--
 

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -5,7 +5,7 @@ const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
 const DELAY_GRACE_PERIOD = 1000 * 30 // 30s
 
 module.exports = class PeerDiscovery {
-  constructor (swarm, topic, { onpeer = noop, onerror = noop }) {
+  constructor (swarm, topic, { onpeer = noop, onerror = safetyCatch }) {
     this.swarm = swarm
     this.topic = topic
     this.isClient = false
@@ -28,17 +28,10 @@ module.exports = class PeerDiscovery {
     this.refresh().catch(this._onerror)
   }
 
-  session ({ server = true, client = true }) {
+  session (opts) {
     if (this.destroyed) throw new Error('PeerDiscovery is destroyed')
-
-    if (client) this._clientSessions++
-    if (server) this._serverSessions++
-
-    const session = new PeerDiscoverySession(this, { server, client })
+    const session = new PeerDiscoverySession(this, opts)
     this._sessions.push(session)
-
-    this.refresh().catch(safetyCatch)
-
     return session
   }
 
@@ -165,11 +158,18 @@ module.exports = class PeerDiscovery {
 }
 
 class PeerDiscoverySession {
-  constructor (discovery, { server = true, client = true }) {
+  constructor (discovery, { server = true, client = true, onerror = safetyCatch }) {
     this.discovery = discovery
     this.isClient = client
     this.isServer = server
     this.destroyed = false
+
+    this._onerror = onerror
+
+    if (client) this.discovery._clientSessions++
+    if (server) this.discovery._serverSessions++
+
+    this.refresh().catch(this._onerror)
   }
 
   get swarm () {


### PR DESCRIPTION
The `PeerDiscovery` instance is now never surfaced to the caller who instead gets back a `PeerDiscoverySession` instance on `swarm.join()`. Multiple independant sessions may be created with different options with the underlying `PeerDiscovery` instance determining based on reference counts whether it should act as server, client, or both. When the last session is destroyed, the `PeerDiscovery` instance is also destroyed. The `PeerDiscovery` instance may also be destroyed directly using `swarm.leave()` per the existing flow.