### PR TITLE
PeerDiscovery._destroyMaybe calls this.swarm.leave

### DIFF
--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -142,7 +142,7 @@ module.exports = class PeerDiscovery {
   }
 
   async _destroyMaybe () {
-    if (this._sessions.length === 0) await this.destroy()
+    if (this._sessions.length === 0) await this.swarm.leave(this.topic)
     else if (this._serverSessions === 0 && this._needsUnannounce) await this.refresh()
   }
 

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -556,19 +556,21 @@ test('multiple discovery sessions with different opts', async (t) => {
 test('closing all discovery sessions clears all peer-discovery objects', async t => {
   const { bootstrap } = await createTestnet(3, t.teardown)
 
-  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm = new Hyperswarm({ bootstrap })
 
   const topic1 = Buffer.alloc(32).fill('hello')
   const topic2 = Buffer.alloc(32).fill('world')
 
-  const discovery1 = swarm1.join(topic1, { client: true, server: false })
-  const discovery2 = swarm1.join(topic2, { client: false, server: true })
+  const discovery1 = swarm.join(topic1, { client: true, server: false })
+  const discovery2 = swarm.join(topic2, { client: false, server: true })
 
-  t.is(swarm1._discovery.size, 2)
+  t.is(swarm._discovery.size, 2)
 
   await Promise.all([discovery1.destroy(), discovery2.destroy()])
 
-  t.is(swarm1._discovery.size, 0)
+  t.is(swarm._discovery.size, 0)
+
+  await swarm.destroy()
 })
 
 function noop () {}

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -553,4 +553,22 @@ test('multiple discovery sessions with different opts', async (t) => {
   await swarm2.destroy()
 })
 
+test('closing all discovery sessions clears all peer-discovery objects', async t => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const swarm1 = new Hyperswarm({ bootstrap })
+
+  const topic1 = Buffer.alloc(32).fill('hello')
+  const topic2 = Buffer.alloc(32).fill('world')
+
+  const discovery1 = swarm1.join(topic1, { client: true, server: false })
+  const discovery2 = swarm1.join(topic2, { client: false, server: true })
+
+  t.is(swarm1._discovery.size, 2)
+
+  await Promise.all([discovery1.destroy(), discovery2.destroy()])
+
+  t.is(swarm1._discovery.size, 0)
+})
+
 function noop () {}


### PR DESCRIPTION
Closing the last remaining `PeerDiscoverySession` for a topic will currently not delete the `PeerDiscovery` object from the `swarm._discovery` `Map`. If  `PeerDiscovery.destroy` is always called through `Hyperswarm.leave`, then all discovery objects will be fully GC'd on leave.