### PR TITLE
remove v3 note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 A high-level API for finding and connecting to peers who are interested in a "topic."
 
-## NOTE: v3
-
-Note that this is the README for v3 which is tagged under next. To see the v2 documentation/code go to https://github.com/hyperswarm/hyperswarm/tree/v2
-
-As v3 fully matures over the next month it will be shifted to npm latest.
-
 ## Installation
 ```
 npm install hyperswarm@next


### PR DESCRIPTION
Now that v4 is latest it seems like this is safe to remove.