### PR TITLE
make refresh wait for previous destroys

### DIFF
--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -5,12 +5,13 @@ const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
 const DELAY_GRACE_PERIOD = 1000 * 30 // 30s
 
 module.exports = class PeerDiscovery {
-  constructor (swarm, topic, { onpeer = noop, onerror = safetyCatch }) {
+  constructor (swarm, topic, { wait = null, onpeer = noop, onerror = safetyCatch }) {
     this.swarm = swarm
     this.topic = topic
     this.isClient = false
     this.isServer = false
     this.destroyed = false
+    this.destroying = null
 
     this._sessions = []
     this._clientSessions = 0
@@ -26,6 +27,7 @@ module.exports = class PeerDiscovery {
     this._firstAnnounce = true
     this._needsUnannounce = false
     this._refreshes = 0
+    this._wait = wait
   }
 
   session ({ server = true, client = true, onerror = safetyCatch }) {
@@ -57,6 +59,13 @@ module.exports = class PeerDiscovery {
   // TODO: Maybe announce should be a setter?
   async _refresh () {
     const clock = ++this._refreshes
+
+    if (this._wait) {
+      await this._wait
+      this._wait = null
+      if (clock !== this._refreshes) return
+    }
+
     const clear = this.isServer && this._firstAnnounce
     if (clear) this._firstAnnounce = false
 
@@ -142,13 +151,22 @@ module.exports = class PeerDiscovery {
   }
 
   async _destroyMaybe () {
+    if (this.destroyed) return
     if (this._sessions.length === 0) await this.swarm.leave(this.topic)
     else if (this._serverSessions === 0 && this._needsUnannounce) await this.refresh()
   }
 
-  async destroy () {
+  destroy () {
+    if (this.destroying) return this.destroying
+    this.destroying = this._destroy()
+    return this.destroying
+  }
+
+  async _destroy () {
     if (this.destroyed) return
     this.destroyed = true
+
+    if (this._wait) await this._wait
 
     if (this._activeQuery) {
       this._activeQuery.destroy()


### PR DESCRIPTION
This could be implemented a bit better, but that requires a bit heavier refactor of the discovery internals (that we should do later on)